### PR TITLE
Use the built container for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "DevContainer for Haskell (GHC, Stack, Cabal, HIE, LSP, DAP, etc.)",
-    "dockerFile": "Dockerfile",
+    "dockerFile": "from-ghcr.dockerfile",
     "context":"..",
     "runArgs": [],
     "settings": {

--- a/.devcontainer/from-ghcr.dockerfile
+++ b/.devcontainer/from-ghcr.dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/viluon/lession-hs:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,8 +41,8 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./.devcontainer/
-        push: false
-        tags: user/app:latest
+        push: true
+        tags: ghcr.io/viluon/lession-hs:latest
         build-args: |
           GHC_VERSION=${{ matrix.ghc }}
           STACK_RESOLVER=${{ matrix.resolver }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,7 @@
 name: Docker Image CI
 on:
   push:
-    branches: [main, setup/ci]
+    branches: [main, setup/*]
   pull_request:
     branches: [main]
 jobs:


### PR DESCRIPTION
It's quite stupid that codespaces has to build the image from scratch after CI passes, isn't it